### PR TITLE
feature/support for monorepo

### DIFF
--- a/src/bundler/constants/bundler-options-defaults.config.ts
+++ b/src/bundler/constants/bundler-options-defaults.config.ts
@@ -54,5 +54,10 @@ globalThis.__dirname = _private_path.dirname(__filename);
  */
 ` as const
 
-export const PACK_ENTITIES = (targetDir: string, rootAssets: string[]) =>
-    ['*.png ', '*.plist', 'README.md', `${targetDir}/**`, 'package.json'].concat(rootAssets.map((a) => `"${a}"`))
+export const WORKFLOW_METADATA_FILES = ['*.png ', '*.plist', 'README.md', 'package.json']
+export const SAFE_ROOT_ASSETS = (rootAssets: string[]) => rootAssets.map((path) => `"${path}"`)
+export const PACK_ENTITIES = (files: string[], flatDirectories: boolean) => {
+    const res = [...files]
+    flatDirectories && res.unshift(`-j`)
+    return res
+}

--- a/src/bundler/models/bundler-options.model.ts
+++ b/src/bundler/models/bundler-options.model.ts
@@ -6,7 +6,7 @@ export interface BundlerOptions {
      * Additional assets to be included in the bundle.
      * Would be located in the `assets` directory.
      *
-     * @default
+     * @note
      * By default, it includes the `run-node.sh` file - in order to call the compiled file (do not use `node` command directly).
      */
     assets?: string[]

--- a/src/cli/commands/pack/models/pack-command-options.model.ts
+++ b/src/cli/commands/pack/models/pack-command-options.model.ts
@@ -2,4 +2,5 @@ export interface PackCommandOptions {
     targetVersion: string
     verbose: boolean
     noPack: boolean
+    noPackageJson: boolean
 }

--- a/src/cli/commands/pack/pack.command.ts
+++ b/src/cli/commands/pack/pack.command.ts
@@ -57,8 +57,18 @@ export class PackCommand extends CommandRunner {
         return true
     }
 
+    @Option({
+        name: 'noPackageJson',
+        flags: '--no-package-json',
+        defaultValue: false,
+        description: 'Do not update the package.json & package-lock.json files.',
+    })
+    private noPackageJson(): boolean {
+        return true
+    }
+
     public async run(passedParams: string[], options?: PackCommandOptions): Promise<void> {
-        const { targetVersion, verbose, noPack } = options ?? {}
+        const { targetVersion, verbose, noPack, noPackageJson } = options ?? {}
 
         if (verbose) {
             this.logger.setLogLevel('verbose')
@@ -93,7 +103,7 @@ export class PackCommand extends CommandRunner {
 
         try {
             await this.buildWorkflow()
-            await this.updateWorkflowVersion(parsedTargetVersion)
+            await this.updateWorkflowVersion(parsedTargetVersion, noPackageJson)
 
             if (noPack) {
                 return
@@ -110,9 +120,12 @@ export class PackCommand extends CommandRunner {
         }
     }
 
-    private async updateWorkflowVersion(version: string): Promise<void> {
+    private async updateWorkflowVersion(version: string, noPackageJson: boolean = false): Promise<void> {
         try {
-            const prms = [updateWorkflowMetadataVersion(version), updateWorkflowPackageJsonVersion(version)]
+            const prms = [
+                updateWorkflowMetadataVersion(version),
+                !noPackageJson && updateWorkflowPackageJsonVersion(version),
+            ]
             await Promise.all(prms)
         } catch (error) {
             this.logger.verbose(`Failed to update Alfred Workflow version - ${error.stack}`)


### PR DESCRIPTION
- **chore: change resolution of JSDocs**
- **fix: split workflow packing into multiple steps, to allow gather build output from different locations - `fast-alfred` now supports monorepo 🥷**
- **feat(cli): support `--no-package-json` flag to aviod updating the `package.json` & `package-loc.json` files**
